### PR TITLE
fix(templates): use section.class CSS selectors for layout templates

### DIFF
--- a/templates/layouts/before-after.yaml
+++ b/templates/layouts/before-after.yaml
@@ -83,32 +83,32 @@ output: |
   </div>
 
 css: |
-  .before-after-slide .before-after-container {
+  section.before-after-slide .before-after-container {
     display: flex;
     gap: 2em;
     justify-content: center;
     align-items: flex-start;
     width: 100%;
   }
-  .before-after-slide.layout-horizontal .before-after-container {
+  section.before-after-slide.layout-horizontal .before-after-container {
     flex-direction: row;
   }
-  .before-after-slide.layout-vertical .before-after-container {
+  section.before-after-slide.layout-vertical .before-after-container {
     flex-direction: column;
     align-items: center;
   }
-  .before-after-slide .before-section,
-  .before-after-slide .after-section {
+  section.before-after-slide .before-section,
+  section.before-after-slide .after-section {
     flex: 1;
     text-align: center;
     position: relative;
   }
-  .before-after-slide.layout-vertical .before-section,
-  .before-after-slide.layout-vertical .after-section {
+  section.before-after-slide.layout-vertical .before-section,
+  section.before-after-slide.layout-vertical .after-section {
     width: 80%;
     flex: none;
   }
-  .before-after-slide .comparison-label {
+  section.before-after-slide .comparison-label {
     display: inline-block;
     padding: 0.3em 1em;
     background: #333;
@@ -118,21 +118,21 @@ css: |
     border-radius: 4px;
     margin-bottom: 0.5em;
   }
-  .before-after-slide .before-section .comparison-label {
+  section.before-after-slide .before-section .comparison-label {
     background: #666;
   }
-  .before-after-slide .after-section .comparison-label {
+  section.before-after-slide .after-section .comparison-label {
     background: #2196F3;
   }
-  .before-after-slide .before-section img,
-  .before-after-slide .after-section img {
+  section.before-after-slide .before-section img,
+  section.before-after-slide .after-section img {
     max-width: 100%;
     max-height: 300px;
     object-fit: contain;
     border-radius: 4px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
-  .before-after-slide .comparison-caption {
+  section.before-after-slide .comparison-caption {
     font-size: 0.85em;
     color: #666;
     margin-top: 0.5em;

--- a/templates/layouts/gallery.yaml
+++ b/templates/layouts/gallery.yaml
@@ -67,27 +67,27 @@ output: |
   </div>
 
 css: |
-  .gallery-slide .gallery-container {
+  section.gallery-slide .gallery-container {
     display: grid;
     gap: 1em;
     width: 100%;
     justify-items: center;
   }
-  .gallery-slide .gallery-cols-2 { grid-template-columns: repeat(2, 1fr); }
-  .gallery-slide .gallery-cols-3 { grid-template-columns: repeat(3, 1fr); }
-  .gallery-slide .gallery-cols-4 { grid-template-columns: repeat(4, 1fr); }
-  .gallery-slide .gallery-cols-5 { grid-template-columns: repeat(5, 1fr); }
-  .gallery-slide .gallery-cols-6 { grid-template-columns: repeat(6, 1fr); }
-  .gallery-slide .gallery-item {
+  section.gallery-slide .gallery-cols-2 { grid-template-columns: repeat(2, 1fr); }
+  section.gallery-slide .gallery-cols-3 { grid-template-columns: repeat(3, 1fr); }
+  section.gallery-slide .gallery-cols-4 { grid-template-columns: repeat(4, 1fr); }
+  section.gallery-slide .gallery-cols-5 { grid-template-columns: repeat(5, 1fr); }
+  section.gallery-slide .gallery-cols-6 { grid-template-columns: repeat(6, 1fr); }
+  section.gallery-slide .gallery-item {
     text-align: center;
     margin: 0;
   }
-  .gallery-slide .gallery-item img {
+  section.gallery-slide .gallery-item img {
     max-width: 100%;
     height: auto;
     border-radius: 4px;
   }
-  .gallery-slide .gallery-item figcaption {
+  section.gallery-slide .gallery-item figcaption {
     font-size: 0.85em;
     color: #666;
     margin-top: 0.5em;

--- a/templates/layouts/image-caption.yaml
+++ b/templates/layouts/image-caption.yaml
@@ -45,32 +45,32 @@ output: |
   </figure>
 
 css: |
-  .image-caption-slide .image-caption-container {
+  section.image-caption-slide .image-caption-container {
     display: flex;
     flex-direction: column;
     align-items: center;
     margin: 0 auto;
     max-width: 90%;
   }
-  .image-caption-slide .image-caption-container img {
+  section.image-caption-slide .image-caption-container img {
     max-width: 100%;
     max-height: 400px;
     object-fit: contain;
     border-radius: 4px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   }
-  .image-caption-slide figcaption {
+  section.image-caption-slide figcaption {
     width: 100%;
     margin-top: 1em;
     text-align: left;
   }
-  .image-caption-slide .caption-text {
+  section.image-caption-slide .caption-text {
     font-size: 0.95em;
     color: #333;
     line-height: 1.5;
     margin: 0;
   }
-  .image-caption-slide .caption-source {
+  section.image-caption-slide .caption-source {
     font-size: 0.85em;
     color: #666;
     font-style: italic;

--- a/templates/layouts/image-full.yaml
+++ b/templates/layouts/image-full.yaml
@@ -57,10 +57,10 @@ output: |
   </div>
 
 css: |
-  .image-full-slide {
+  section.image-full-slide {
     padding: 0;
   }
-  .image-full-slide .image-full {
+  section.image-full-slide .image-full {
     width: 100%;
     height: 100%;
     background-size: cover;
@@ -71,7 +71,7 @@ css: |
     align-items: center;
     position: relative;
   }
-  .image-full-slide .overlay {
+  section.image-full-slide .overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -79,16 +79,16 @@ css: |
     height: 100%;
     z-index: 1;
   }
-  .image-full-slide .overlay-dark {
+  section.image-full-slide .overlay-dark {
     background: rgba(0, 0, 0, 0.5);
   }
-  .image-full-slide .overlay-light {
+  section.image-full-slide .overlay-light {
     background: rgba(255, 255, 255, 0.5);
   }
-  .image-full-slide .overlay-gradient {
+  section.image-full-slide .overlay-gradient {
     background: linear-gradient(to bottom, transparent 50%, rgba(0, 0, 0, 0.7));
   }
-  .image-full-slide .image-title {
+  section.image-full-slide .image-title {
     position: relative;
     z-index: 2;
     color: white;
@@ -96,7 +96,7 @@ css: |
     font-size: 2.5em;
     margin: 0;
   }
-  .image-full-slide .image-caption {
+  section.image-full-slide .image-caption {
     position: relative;
     z-index: 2;
     color: white;

--- a/templates/layouts/image-text.yaml
+++ b/templates/layouts/image-text.yaml
@@ -80,30 +80,30 @@ output: |
   </div>
 
 css: |
-  .image-text-slide .image-text-container {
+  section.image-text-slide .image-text-container {
     display: flex;
     gap: 2em;
     align-items: center;
     height: 80%;
   }
-  .image-text-slide.image-right .image-text-container {
+  section.image-text-slide.image-right .image-text-container {
     flex-direction: row-reverse;
   }
-  .image-text-slide .image-section {
+  section.image-text-slide .image-section {
     flex: 1;
     text-align: center;
   }
-  .image-text-slide .image-section img {
+  section.image-text-slide .image-section img {
     max-width: 100%;
     max-height: 400px;
     object-fit: contain;
   }
-  .image-text-slide .image-caption {
+  section.image-text-slide .image-caption {
     font-style: italic;
     color: #666;
     margin-top: 0.5em;
     font-size: 0.9em;
   }
-  .image-text-slide .text-section {
+  section.image-text-slide .text-section {
     flex: 1;
   }

--- a/templates/layouts/three-column.yaml
+++ b/templates/layouts/three-column.yaml
@@ -78,26 +78,26 @@ output: |
   </div>
 
 css: |
-  .three-column-slide .column-container {
+  section.three-column-slide .column-container {
     display: flex;
     gap: 1.5em;
     width: 100%;
     justify-content: space-between;
   }
-  .three-column-slide .column {
+  section.three-column-slide .column {
     flex: 1;
     text-align: center;
     padding: 1em;
   }
-  .three-column-slide .column-icon {
+  section.three-column-slide .column-icon {
     font-size: 2em;
     display: block;
     margin-bottom: 0.5em;
   }
-  .three-column-slide .column-title {
+  section.three-column-slide .column-title {
     font-weight: bold;
     margin-bottom: 0.5em;
   }
-  .three-column-slide .column-content {
+  section.three-column-slide .column-content {
     text-align: left;
   }

--- a/templates/layouts/two-column.yaml
+++ b/templates/layouts/two-column.yaml
@@ -75,15 +75,15 @@ output: |
   </div>
 
 css: |
-  .two-column-slide .two-column-container {
+  section.two-column-slide .two-column-container {
     display: flex;
     gap: 2em;
     width: 100%;
     height: 80%;
   }
-  .two-column-slide .column-left {
+  section.two-column-slide .column-left {
     flex: var(--left-ratio, 50);
   }
-  .two-column-slide .column-right {
+  section.two-column-slide .column-right {
     flex: var(--right-ratio, 50);
   }


### PR DESCRIPTION
## Summary

- Change CSS selectors from `.class` to `section.class` format in all layout templates
- Fixes layout templates not displaying properly when using `<!-- _class: foo -->` directive

## Problem

When `<!-- _class: foo -->` is used, the class is applied to the `<section>` element itself. The previous CSS selectors `.foo .container` searched for descendants of an element with class `foo`, which didn't match. The fix uses `section.foo .container` which correctly targets elements inside a section with that class.

## Changes

| Template | Selector Change |
|----------|----------------|
| two-column | `.two-column-slide` → `section.two-column-slide` |
| three-column | `.three-column-slide` → `section.three-column-slide` |
| image-text | `.image-text-slide` → `section.image-text-slide` |
| before-after | `.before-after-slide` → `section.before-after-slide` |
| gallery | `.gallery-slide` → `section.gallery-slide` |
| image-caption | `.image-caption-slide` → `section.image-caption-slide` |
| image-full | `.image-full-slide` → `section.image-full-slide` |

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Visual regression test with `templates screenshot` confirms all layouts display correctly

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)