### PR TITLE
docs(templates): add CSS guidelines and custom template creation guide

### DIFF
--- a/spec/templates.md
+++ b/spec/templates.md
@@ -368,7 +368,7 @@ When creating or modifying templates, follow these critical rules to ensure prop
 ### 1. CSS Selector Rules (Marp Scoping)
 
 When using `<!-- _class: foo -->`, the class is added to the `<section>` element itself.
-Therefore, CSS selectors must use `section.class` format.
+Use `section.class` when you need to target the `<section>` element directly (or avoid matching non-`section` elements).
 
 #### Correct Pattern
 
@@ -380,14 +380,14 @@ section.my-slide .container { display: flex; }
 .container { padding: 1em; }
 ```
 
-#### Incorrect Pattern
+#### Incorrect Pattern (for targeting the section element)
 
 ```css
-/* This does NOT work - selector looks for descendants of .my-slide */
+/* This targets descendants, not the section element itself */
 .my-slide .container { display: flex; }
 ```
 
-**Why this happens**: Marp applies `<!-- _class: foo -->` directly to the `<section>` tag, creating `<section class="foo">`. The selector `.foo .container` looks for `.container` inside an element with class `foo`, but `.container` is inside the same `<section>` element, not a descendant.
+**Why this happens**: Marp applies `<!-- _class: foo -->` directly to the `<section>` tag, creating `<section class="foo">`. The selector `.foo .container` is valid for descendants inside that section, but it does not target the `<section>` element itself.
 
 ### 2. HTML + Markdown Rules (CommonMark)
 

--- a/src/cli/templates/ai/references/templates-ref.ts
+++ b/src/cli/templates/ai/references/templates-ref.ts
@@ -131,15 +131,17 @@ css: |
 
 When using \`<!-- _class: foo -->\`, Marp adds class to the \`<section>\` element.
 
-**Correct:**
+**Correct (targeting the section element):**
 \`\`\`css
 section.foo .child { ... }
 \`\`\`
 
-**Wrong (will NOT work):**
+**Wrong (for targeting the section element):**
 \`\`\`css
 .foo .child { ... }
 \`\`\`
+
+Note: \`.foo .child\` is valid for descendants inside the section, but it does not target the \`<section>\` element itself.
 
 ### Critical HTML Rule: CommonMark
 

--- a/src/cli/templates/ai/skill-md.ts
+++ b/src/cli/templates/ai/skill-md.ts
@@ -210,7 +210,7 @@ When creating or modifying templates, follow these critical rules.
 
 When using \`<!-- _class: foo -->\`:
 - The class is added to \`<section>\` element itself
-- CSS must use \`section.foo\` format, NOT \`.foo\`
+- Use \`section.foo\` when targeting the \`<section>\` element itself
 
 \`\`\`yaml
 # Correct
@@ -223,10 +223,12 @@ css: |
 \`\`\`
 
 \`\`\`yaml
-# WRONG - This will NOT work
+# WRONG - This does not target the section element itself
 css: |
   .my-slide .container { display: flex; }
 \`\`\`
+
+Note: \`.my-slide .container\` is valid for descendants inside the section, but it does not target the \`<section>\` element itself.
 
 #### 2. HTML + Markdown (CommonMark)
 


### PR DESCRIPTION
## Summary

- Add Template Writing Guidelines section to spec/templates.md with CSS selector rules (Marp scoping), HTML+Markdown rules (CommonMark), and visual verification procedures
- Add custom template creation guidelines to AI Agent skill template (skill-md.ts)
- Add detailed custom template creation guide to references (templates-ref.ts)
- Update existing cycle-diagram CSS example to use correct `section.class` pattern

## Related

- Closes #22 (documentation follow-up)
- Related to task #44 (spec/tasks/44-template-css-guidelines.md)
- Follow-up to #26 (task #43 Layout CSS Fix)

## Test plan

- [x] All existing tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes (`pnpm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)